### PR TITLE
compress node.data using gzip (to save traffic)

### DIFF
--- a/package/nodewatcher/files/usr/sbin/nodewatcher
+++ b/package/nodewatcher/files/usr/sbin/nodewatcher
@@ -194,7 +194,7 @@ crawl() {
 	DATA="<?xml version='1.0' standalone='yes'?><data><system_data>$SYSTEM_DATA</system_data><interface_data>$interface_data</interface_data><batman_adv_interfaces>$BATMAN_ADV_INTERFACES</batman_adv_interfaces><batman_adv_originators>$batman_adv_originators</batman_adv_originators><batman_adv_gateway_mode>$batman_adv_gateway_mode</batman_adv_gateway_mode><batman_adv_gateway_list>$batman_adv_gateway_list</batman_adv_gateway_list><client_count>$client_count</client_count></data>"
 
 	#write data to hxml file that provides the data on httpd
-	echo $DATA > $SCRIPT_DATA_FILE
+	echo $DATA | gzip > $SCRIPT_DATA_FILE
 }
 
 LANG=C


### PR DESCRIPTION
netmon supports gzip compressed node.data as of
https://git.nordwest.freifunk.net/ffnw/netmon/commit/d96458744bfdea81096998f196b833248f98b848
